### PR TITLE
Fix/file message parse

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty-puppet-whatsapp",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Wechaty Puppet for WhatsApp",
   "type": "module",
   "exports": {

--- a/src/whatsapp/event-handler/message-event-handler.ts
+++ b/src/whatsapp/event-handler/message-event-handler.ts
@@ -44,7 +44,7 @@ export default class MessageEventHandler extends WhatsAppBase {
       return
     }
     await cacheManager.setMessageRawPayload(messageId, message)
-    if ((message as WhatsAppMessagePayload)._data.caption) { // see issue: https://github.com/wechaty/puppet-whatsapp/issues/390
+    if ((message as WhatsAppMessagePayload)._data?.caption) { // see issue: https://github.com/wechaty/puppet-whatsapp/issues/390
       const genTextMessageFromImageMessage = message as WhatsAppMessagePayload
       genTextMessageFromImageMessage.type = WhatsAppMessageType.TEXT
       const textMsgId = `${genTextMessageFromImageMessage.id.id}_TEXT`


### PR DESCRIPTION
有些消息不包含_data
例如：
15:27:51 INFO MessageEventHandler onMessage({"mediaKey":"T6JA1CMc1Idai7mWXXRvp/ECZnWKiYHKycv1C+5329A=","id":{"fromMe":false,"remote":"8615210838378@c.us","id":"3EB00AC8AE08DF7E7E10_TEXT","_serialized":"false_8615210838378@c.us_3EB00AC8AE08DF7E7E10"},"ack":1,"hasMedia":true,"body":"API 工程化.pdf","type":"chat","timestamp":1667460471,"from":"8615210838378@c.us","to":"8618500946096@c.us","deviceType":"web","isForwarded":false,"forwardingScore":0,"isStatus":false,"isStarred":false,"broadcast":false,"fromMe":false,"hasQuotedMsg":false,"vCards":[],"mentionedIds":[],"isGif":false,"isEphemeral":false,"links":[]})