### PR TITLE
chore: upgrade whatsapp-web.js to 1.30.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty-puppet-whatsapp",
-  "version": "1.0.88",
+  "version": "1.0.89",
   "description": "Wechaty Puppet for WhatsApp",
   "type": "module",
   "exports": {
@@ -69,7 +69,7 @@
     "@juzi/wechaty-puppet": "^1.0.15"
   },
   "dependencies": {
-    "@juzi/whatsapp-web.js": "^1.30.28",
+    "@juzi/whatsapp-web.js": "^1.30.29",
     "ee-ts": "^1.0.2",
     "flash-store": "^1.0.6",
     "fs-extra": "^10.0.1",


### PR DESCRIPTION
## Summary
- upgrade `@juzi/whatsapp-web.js` to `^1.30.29`
- bump `@juzi/wechaty-puppet-whatsapp` to `1.0.89`
- keep the existing `chrome_oom` to `PUPPETEER EXPLORER OOM` forwarding unchanged

Blocked until `@juzi/whatsapp-web.js@1.30.29` is published.

## Test plan
- [x] `npm run build`
- [x] lint passed
- [x] local package-chain harness: `ERR_BLOB_OUT_OF_MEMORY -> chrome_oom -> PUPPETEER EXPLORER OOM`
- [ ] full `npm test`: the real-browser suite requires a locally installed Chrome; the other 13 suites passed