### PR TITLE
fix: pin Node types in pack test

### DIFF
--- a/scripts/npm-pack-testing.sh
+++ b/scripts/npm-pack-testing.sh
@@ -21,7 +21,7 @@ cd $TMPDIR
 
 npm init -y
 npm install --production *-*.*.*.tgz \
-  @types/node \
+  @types/node@18 \
   @chatie/tsconfig@$NPM_TAG \
   @juzi/wechaty-puppet@$NPM_TAG \
   @juzi/wechaty@$NPM_TAG \


### PR DESCRIPTION
## Summary
- pin `@types/node` to major 18 in package smoke testing
- keep the type definitions compatible with the TypeScript 4.9 compiler installed by `@chatie/tsconfig`
- unblock publishing `@juzi/wechaty-puppet-whatsapp@1.0.89`

## Root cause
The pack test installed unpinned `@types/node@latest` (currently 26.1.1) together with TypeScript 4.9.5. TypeScript 4.9 cannot parse syntax in the latest Node type declarations, so the Pack job failed before Publish.

## Test plan
- `bash -n scripts/npm-pack-testing.sh`
- `npm test` (lint/type checks pass; real-Chrome startup test remains unavailable locally because the Puppeteer browser is not installed)
- packed tarball smoke compile/run with `@types/node@18.19.130` and TypeScript `4.9.5`: `Puppet v1.0.89 smoke testing passed.`