### PR TITLE
fix: remove pkg-jq from publish path

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -86,8 +86,8 @@ jobs:
       - name: Is A Publish Branch
         if: steps.check-branch.outputs.match == 'true'
         run: |
-          NAME=$(npx pkg-jq -r .name)
-          VERSION=$(npx pkg-jq -r .version)
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
           if npx version-exists "$NAME" "$VERSION"
           then echo "$NAME@$VERSION exists on NPM, skipped."
           else npm publish

--- a/scripts/package-publish-config-tag.sh
+++ b/scripts/package-publish-config-tag.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
-VERSION=$(npx pkg-jq -r .version)
+VERSION=$(node -p "require('./package.json').version")
 
 if npx --package @chatie/semver semver-is-prod $VERSION; then
-  npx pkg-jq -i '.publishConfig.tag="latest"'
+  npm pkg set publishConfig.tag=latest
   echo "production release: publicConfig.tag set to latest."
 else
-  npx pkg-jq -i '.publishConfig.tag="next"'
+  npm pkg set publishConfig.tag=next
   echo 'development release: publicConfig.tag set to next.'
 fi
-


### PR DESCRIPTION
## Summary
- replace `pkg-jq` in the publish path with built-in Node/npm commands
- avoid the missing `node-jq` executable on the Node 22 publish runner
- unblock publishing the existing `1.0.89` package version

## Root cause
The Publish job failed in `Set Publish Config` because `pkg-jq` attempted to spawn `node_modules/node-jq/bin/jq`, which was not installed in the current Node 22/npm environment. The later version lookup used the same dependency and would fail for the same reason.

## Test plan
- validate shell syntax and workflow YAML parsing
- verify `1.0.89` selects npm tag `latest`
- verify `1.0.90-next.0` selects npm tag `next`